### PR TITLE
Constructor parameters for DbContextFactory

### DIFF
--- a/EntityFramework.Inject.Spec.net40/EntityFramework.Inject.Spec.net40.csproj
+++ b/EntityFramework.Inject.Spec.net40/EntityFramework.Inject.Spec.net40.csproj
@@ -76,6 +76,9 @@
     <None Include="App.config" />
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/EntityFramework.Inject.Spec/Entities/TestDbContext.cs
+++ b/EntityFramework.Inject.Spec/Entities/TestDbContext.cs
@@ -1,11 +1,27 @@
-﻿using System.Data.Entity;
+﻿using System.Collections.Generic;
+using System.Data.Entity;
+using System.Diagnostics;
+using Method.Inject;
 
 namespace EntityFramework.Inject.Spec.Entities
 {
 	public class TestDbContext : DbContext
 	{
-		public TestDbContext(string nameOrConnectionString) : base(nameOrConnectionString)
-		{
-		}
+	    public object StringParameter { get; private set; }
+	    public object ObjectParameter { get; private set; }
+	    public InjectionSet ClassParameter { get; private set; }
+	    public IEnumerable<int> InterfaceParameter { get; private set; }
+
+	    public TestDbContext(string nameOrConnectionString ) : base(nameOrConnectionString)
+	    {
+	    }
+
+	    public TestDbContext(string nameOrConnectionString, object stringParameter, object objectParameter, InjectionSet classParameter, IEnumerable<int> interfaceParameter) : base(nameOrConnectionString)
+	    {
+	        StringParameter = stringParameter;
+	        ObjectParameter = objectParameter;
+	        ClassParameter = classParameter;
+	        InterfaceParameter = interfaceParameter;
+	    }
 	}
 }

--- a/EntityFramework.Inject.Spec/Localization/DbContextFactorySpec.cs
+++ b/EntityFramework.Inject.Spec/Localization/DbContextFactorySpec.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Data.Entity;
 using System.Linq;
 using EntityFramework.Inject.Emit;
@@ -61,19 +62,19 @@ namespace EntityFramework.Inject.Spec.Localization
 			
 			int assemblyCount = AppDomain.CurrentDomain.GetAssemblies().Length;
 
-			var types = _factory.CreateTypes(new InjectionSet(injection), typeof(TestDbContext1), typeof(TestDbContext2));
+			var types = _factory.CreateTypes(new InjectionSet(injection), null, typeof(TestDbContext1), typeof(TestDbContext2));
 			Assert.That(types.Length, Is.EqualTo(2));
 			Assert.That(AppDomain.CurrentDomain.GetAssemblies().Length, Is.EqualTo(assemblyCount + 1));
 			var type1 = types[0];
 			var type2 = types[1];
 
-			types = _factory.CreateTypes(new InjectionSet(injection), typeof(TestDbContext3), typeof(TestDbContext2));
+			types = _factory.CreateTypes(new InjectionSet(injection), null, typeof(TestDbContext3), typeof(TestDbContext2));
 			Assert.That(types.Length, Is.EqualTo(2));
 			Assert.That(types[1], Is.EqualTo(type2));
 			
 			Assert.That(AppDomain.CurrentDomain.GetAssemblies().Length, Is.EqualTo(assemblyCount + 2));
 
-			types = _factory.CreateTypes(new InjectionSet(injection), typeof(TestDbContext1), typeof(TestDbContext3));
+			types = _factory.CreateTypes(new InjectionSet(injection), null, typeof(TestDbContext1), typeof(TestDbContext3));
 			Assert.That(types.Length, Is.EqualTo(2));
 			Assert.That(types[0], Is.EqualTo(type1));
 			
@@ -95,5 +96,22 @@ namespace EntityFramework.Inject.Spec.Localization
 			});
 			helper.Run(10);
 		}
+
+	    [Test]
+	    public void Should_pass_constructor_parameter_to_context()
+	    {
+            var injectionSet = new InjectionSet();
+	        var stringParameter = "stringParameter";
+	        var objectParameter = (object) "objectParameter";
+            var classParameter = new InjectionSet();
+	        var interfaceParameter = (IEnumerable<int>)new[] {1, 2, 3};
+
+	        var context = _factory.Create<TestDbContext>(injectionSet, new [] { "EntityFrameworkInject", stringParameter, objectParameter, classParameter, interfaceParameter } );
+
+            Assert.That(context.StringParameter, Is.EqualTo(stringParameter));
+            Assert.That( context.ObjectParameter, Is.EqualTo( objectParameter ) );
+            Assert.That( context.ClassParameter, Is.EqualTo( classParameter ) );
+            Assert.That( context.InterfaceParameter, Is.EqualTo( interfaceParameter ) );
+        }
 	}
 }

--- a/EntityFramework.Inject/Emit/InjectedDbContextBuilder.cs
+++ b/EntityFramework.Inject/Emit/InjectedDbContextBuilder.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
 using Method.Inject;
@@ -9,11 +10,14 @@ namespace EntityFramework.Inject.Emit
 {
 	public class InjectedDbContextBuilder : InjectedTypeBuilder
 	{
-		public InjectedDbContextBuilder(TypeBuilder typeBuilder) : base(typeBuilder)
-		{
-		}
+	    private readonly Type[] _constructorParameterTypes;
 
-		/// <summary>
+	    public InjectedDbContextBuilder(TypeBuilder typeBuilder, Type[] constructorParameterTypes = null) : base(typeBuilder)
+	    {
+	        _constructorParameterTypes = constructorParameterTypes;
+	    }
+
+	    /// <summary>
 		/// Builds constructor if necessary (see example). Default implementation builds constructor for base constructor without parameters.
 		/// </summary>
 		/// <example>
@@ -23,30 +27,45 @@ namespace EntityFramework.Inject.Emit
 		/// </example>
 		[SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1650:ElementDocumentationMustBeSpelledCorrectly", Justification = "Reviewed. Suppression is OK here.")]
 		public override void BuildConstructor()
-		{
-			var constructorBuilder =
-				TypeBuilder.DefineConstructor(
-					MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.RTSpecialName,
-					CallingConventions.Standard, new[] { typeof(InjectionSet), typeof(string) });
+	    {
+	        Debug.Assert(TypeBuilder.BaseType != null, "_typeBuilder.BaseType != null");
 
-			Debug.Assert(TypeBuilder.BaseType != null, "_typeBuilder.BaseType != null");
+	        var parameters = _constructorParameterTypes == null
+	            ? new[] {typeof (InjectionSet), typeof (string)}
+	            : new[] {typeof (InjectionSet)}.Concat(_constructorParameterTypes).ToArray();
 
-			var baseConstructor = TypeBuilder.BaseType.GetConstructor(new[] { typeof(string) });
-			if (baseConstructor == null)
-				throw new ArgumentException(
-					string.Format("DbContext {0} does not have a constructor with connectionStringOrName parameter.",
-						TypeBuilder.BaseType));
+            var constructorBuilder = TypeBuilder.DefineConstructor(
+                MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.RTSpecialName,
+                CallingConventions.Standard, parameters );
 
-			var il = constructorBuilder.GetILGenerator();
-			il.Emit(OpCodes.Ldarg_0);
-			il.Emit(OpCodes.Ldarg_2);
-			il.Emit(OpCodes.Call, baseConstructor);
+            var baseConstructor = TypeBuilder.BaseType.GetConstructor( _constructorParameterTypes ?? new []{ typeof( string ) } );
+            if ( baseConstructor == null )
+                throw new ArgumentException(
+                    string.Format( "DbContext {0} does not have a constructor with the specified parameter types. ({1})",
+                        TypeBuilder.BaseType, String.Join(",", parameters.Select( t => t.Name ) ) ) );
 
-			il.Emit(OpCodes.Ldarg_0);
-			il.Emit(OpCodes.Ldarg_1);
-			il.Emit(OpCodes.Stfld, InjectionSetField);
 
-			il.Emit(OpCodes.Ret);
-		}
-	}
+            var il = constructorBuilder.GetILGenerator();
+
+            il.Emit( OpCodes.Ldarg_0 );
+	        if (_constructorParameterTypes == null)
+	        {
+                il.Emit( OpCodes.Ldarg_2 );    
+            }
+            else
+	        {
+                for ( int i = 2; i < _constructorParameterTypes.Length + 2; ++i )
+                {
+                    il.Emit( OpCodes.Ldarg, i );
+                }
+            }
+            il.Emit( OpCodes.Call, baseConstructor );
+
+            il.Emit( OpCodes.Ldarg_0 );
+            il.Emit( OpCodes.Ldarg_1 );
+            il.Emit( OpCodes.Stfld, InjectionSetField );
+
+            il.Emit( OpCodes.Ret );
+        }
+    }
 }


### PR DESCRIPTION
Implemented an additional Create method in DbContextFactory that takes an array of constructor parameters to be passed down to the DbContext constructor.
